### PR TITLE
add COREONE to the list of known printers

### DIFF
--- a/gcode_metadata/metadata.py
+++ b/gcode_metadata/metadata.py
@@ -24,6 +24,7 @@ RE_ESTIMATED = re.compile(r"((?P<days>[0-9]+)d\s*)?"
                           r"((?P<minutes>[0-9]+)m\s*)?"
                           r"((?P<seconds>[0-9]+)s)?")
 PRINTERS = [
+    'COREONE',
     'HT90',
     'MK2.5',
     'MK2.5S',


### PR DESCRIPTION
I have a test with gcode file for the CORE One printer, but I'm thinking it probably won't be necessary, considering we're testing only one model from the list.

So I'm only submitting this one one-liner.
